### PR TITLE
Use Default HateBERT Tokenizer

### DIFF
--- a/toxigen/pretrained_classifiers.py
+++ b/toxigen/pretrained_classifiers.py
@@ -22,7 +22,7 @@ class HateBERT(HateSpeechClassifier):
         HateBERT files: https://huggingface.co/GroNLP/hateBERT
         """
         super(HateBERT, self).__init__()
-        self.tokenizer = AutoTokenizer.from_pretrained(model_path)
+        self.tokenizer = AutoTokenizer.from_pretrained('GroNLP/hateBERT')
         self.model = AutoModelForSequenceClassification.from_pretrained(model_path).eval()
 
 class ToxDectRoBERTa(HateSpeechClassifier):


### PR DESCRIPTION
I ran into an issue integrating with the HateBERT model. The tokenizer is configured for GPT-2 rather than HateBERT. This was causing several errors in our pipeline. I resolved the issue by using the default HateBERT tokenizer. Is this an intentional configuration? I didn't find any references in the paper to using GPT-2's tokenizer when fine-tuning HateBERT and RoBERTa. 

It seems that #8 may be due to the same problem. Having the default tokenizer being GPT-2 is confusing, especially if you're trying to experiment side-by-side with other BERT models.

Thanks,